### PR TITLE
コメントを無視する実装を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SRCS_INLINE_IMG	:= \
 	print_inline_img.c \
 
 SRCS_LOADER	:=\
+	_ignore_comment.c\
 	_load_amb_light.c\
 	_load_camera.c\
 	_load_cylinder.c\

--- a/srcs/loader/_ignore_comment.c
+++ b/srcs/loader/_ignore_comment.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   _ignore_comment.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/10/07 23:25:36 by kfujita           #+#    #+#             */
+/*   Updated: 2023/10/07 23:43:29 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdlib.h>
+
+#include "_rt_loader.h"
+
+#if defined(DEBUG) || defined(ENABLE_PNG)
+
+__attribute__((nonnull))
+static bool	_is_comment(const char *line)
+{
+	return (line[0] == '#');
+}
+
+void	_ignore_comment(char **arr)
+{
+	size_t	i;
+
+	if (arr == NULL || arr[0] == NULL)
+		return ;
+	i = 0;
+	while (arr[i] != NULL && !_is_comment(arr[i]))
+		i++;
+	while (arr[i] != NULL)
+	{
+		free((void *)arr[i]);
+		arr[i++] = NULL;
+	}
+}
+
+#else
+
+void	_ignore_comment(char **arr)
+{
+	(void)arr;
+	return ;
+}
+
+#endif

--- a/srcs/loader/_rt_loader.h
+++ b/srcs/loader/_rt_loader.h
@@ -15,6 +15,11 @@
 
 # include <rt_loader.h>
 
+void		_ignore_comment(
+				char **arr
+				)
+			;
+
 t_amb_light	_load_amb_light(
 				char *const arr[],
 				t_lderr *err

--- a/srcs/loader/loader.c
+++ b/srcs/loader/loader.c
@@ -99,6 +99,7 @@ t_lderr	load_rt_line(
 	if (arr == NULL)
 		return (perr_retint("ft_split", LOAD_ERR_PRINTED));
 	err = LOAD_ERR_SUCCESS;
+	_ignore_comment(arr);
 	if (arr[0] != NULL)
 		err = _parse_input(arr, dst);
 	free2darr((void **)arr);


### PR DESCRIPTION
今更ながら、RTファイルでコメントを使用できるようにする実装を追加しました。
もちろん課題要件には無いため、`DEBUG` あるいは `ENABLE_PNG` がdefineされている場合にのみこの機能が有効化されます。

## 使い方

シェルスクリプトと同じ感じで、各行の`#` から始まる部分を無視します。
(正確には、`ft_split(' ')` の各要素先頭に `#` が存在した場合に、そこ以降を無視する実装です)

行頭からコメントも可能ですし、各行の末尾にコメントを書くといったことも可能です。

## 注意

`#` から行末まで全て無視するため、有効なRTコマンドの途中に `#` を挟むと無効なRTコマンドとして認識されてしまいます。ご注意ください。

## 記述例

```sh
# 正常なコメント
A 1 255,255,255

C 0,2,5 0,0.3,1 50 # 正常なコメント
L 10,10,10 0.6 255,255,255 #正常なコメント (`#`直後に文字を置いてもOK)

# エラーになってしまうコメント例
# 色設定を行う前にコメントアウトしてしまっている
#             ↓
sp 0,0,-2 0.6 # 255,0,0

# エラーになってしまうコメント例
# 行の途中でコメントを開始する際、`#` の前にスペースを入れ忘れている
#.                   ↓
sp 0,0,-2 0.6 255,0,0# 不正なコメント
```

