### PR TITLE
正規化されているはずのベクトルが零ベクトルな際にエラーを吐くようにした

### DIFF
--- a/.tests/_get_lderr_str.h
+++ b/.tests/_get_lderr_str.h
@@ -30,6 +30,7 @@ static const char	*_get_lderr_str(t_lderr err)
 	else IF_RET_ERR_STR(LOAD_ERR_INVAL_ARGS_COUNT)
 	else IF_RET_ERR_STR(LOAD_ERR_TOO_FEW_PARAMS)
 	else IF_RET_ERR_STR(LOAD_ERR_NO_CAMERA)
+	else IF_RET_ERR_STR(LOAD_ERR_NRM_VEC_LEN_ZERO)
 	else
 		return ("(Unknown load_error id)");
 }

--- a/headers/rt_loader.h
+++ b/headers/rt_loader.h
@@ -26,6 +26,7 @@ typedef enum e_load_err
 	LOAD_ERR_INVAL_ARGS_COUNT,
 	LOAD_ERR_TOO_FEW_PARAMS,
 	LOAD_ERR_NO_CAMERA,
+	LOAD_ERR_NRM_VEC_LEN_ZERO,
 }	t_lderr;
 
 /**

--- a/srcs/loader/_parse_vec3.c
+++ b/srcs/loader/_parse_vec3.c
@@ -59,6 +59,8 @@ t_lderr	_parse_vec3(
 		*err = LOAD_ERR_VAL_OUT_OF_RANGE;
 	else if (is_normalized)
 		*dst = vec3_normalize(*dst);
+	if (vec3_len(*dst) == 0)
+		*err = LOAD_ERR_NRM_VEC_LEN_ZERO;
 	free2darr((void **)arr2d);
 	return (*err);
 }

--- a/srcs/loader/print_load_err.c
+++ b/srcs/loader/print_load_err.c
@@ -36,8 +36,14 @@ void	print_load_err(t_lderr err)
 		_print(ERR_MSG_UNKNOWN_TYPE_ID);
 	else if (err == LOAD_ERR_NOT_A_NUMBER)
 		_print(ERR_MSG_NOT_A_NUMBER);
+	else if (err == LOAD_ERR_VAL_OUT_OF_RANGE)
+		_print(ERR_MSG_VAL_OUT_OF_RANGE);
 	else if (err == LOAD_ERR_INVAL_ARGS_COUNT)
 		_print(ERR_MSG_INVAL_ARGS_COUNT);
 	else if (err == LOAD_ERR_TOO_FEW_PARAMS)
 		_print(ERR_MSG_NO_CAMERA);
+	else if (err == LOAD_ERR_NO_CAMERA)
+		_print(ERR_MSG_NO_CAMERA);
+	else
+		_print("unknown error");
 }

--- a/srcs/loader/print_load_err.c
+++ b/srcs/loader/print_load_err.c
@@ -20,6 +20,7 @@
 #define ERR_MSG_INVAL_ARGS_COUNT "invalid arguments length"
 #define ERR_MSG_TOO_FEW_PARAMS "too few parameters"
 #define ERR_MSG_NO_CAMERA "camera is missing"
+#define ERR_MSG_NRM_VEC_LEN_ZERO "invalid normal vector (len is zero)"
 
 static void	_print(const char *const msg)
 {
@@ -44,6 +45,8 @@ void	print_load_err(t_lderr err)
 		_print(ERR_MSG_NO_CAMERA);
 	else if (err == LOAD_ERR_NO_CAMERA)
 		_print(ERR_MSG_NO_CAMERA);
+	else if (err == LOAD_ERR_NRM_VEC_LEN_ZERO)
+		_print(ERR_MSG_NRM_VEC_LEN_ZERO);
 	else
 		_print("unknown error");
 }


### PR DESCRIPTION
例えば `C 0,2,5 0,0.0,0 50` のようにすると、カメラの方向が定まらないため、描画することができない。
そのため、このような時にエラーを吐くようにした。

![Screenshot 2023-12-08 at 21 04 08](https://github.com/TR-42/miniRT/assets/31824852/1997db78-8968-4650-adfe-f38a81bd6913)
