### PR TITLE
実行時引数を指定する機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ NAME	:=	miniRT
 SRCS_MAIN	:= \
 	main.c \
 
+SRCS_ARGS	:=\
+	_arg_allow_comment.c\
+	_arg_atoi.c\
+	_arg_height.c\
+	_arg_width.c\
+	parse_argv.c\
+
 SRCS_CAMERA	:=\
 	cam_get_ray.c\
 
@@ -99,6 +106,7 @@ SRCS_VECT3D :=\
 	vec3_sub.c\
 
 SRCS_NOMAIN	:= \
+	$(addprefix args/, $(SRCS_ARGS))\
 	$(addprefix camera/, $(SRCS_CAMERA))\
 	$(addprefix canvas/, $(SRCS_CANVAS))\
 	$(addprefix cylinder/, $(SRCS_CYLINDER))\

--- a/headers/args.h
+++ b/headers/args.h
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   args.h                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 23:58:12 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/08 23:58:47 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef ARGS_H
+# define ARGS_H
+
+# include "rt_types.h"
+
+bool	parse_argv(
+			int argc,
+			const char *argv[],
+			t_app *app
+			)
+		__attribute__((nonnull))
+		;
+
+#endif

--- a/headers/rt_loader.h
+++ b/headers/rt_loader.h
@@ -37,6 +37,7 @@ typedef enum e_load_err
  */
 t_lderr	load_rt(
 			int fd,
+			bool allow_comment,
 			t_scene *dst
 			)
 		__attribute__((nonnull))
@@ -46,11 +47,13 @@ t_lderr	load_rt(
  * @brief RTファイルの一行を解析し、sceneに記録する
  * 
  * @param line RTファイルの一行
+ * @param allow_comment コメント行を許可するかどうか
  * @param dst sceneを書き込む場所
  * @return t_lderr 読み込み/解析結果 (エラー情報)
  */
 t_lderr	load_rt_line(
 			const char *line,
+			bool allow_comment,
 			t_scene *dst
 			)
 		__attribute__((nonnull))

--- a/headers/rt_types.h
+++ b/headers/rt_types.h
@@ -135,4 +135,13 @@ typedef struct s_scene
 	t_vect		objs;
 }	t_scene;
 
+typedef struct s_app
+{
+	int			height;
+	int			width;
+	bool		allow_comment;
+	const char	*file_name;
+	t_scene		scene;
+}	t_app;
+
 #endif

--- a/srcs/args/_arg_allow_comment.c
+++ b/srcs/args/_arg_allow_comment.c
@@ -1,0 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   _arg_allow_comment.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 23:55:37 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/08 23:56:08 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <ft_string/ft_string.h>
+
+#include "_args.h"
+
+bool	_is_arg_allow_comment(
+	const char *str
+)
+{
+	return (
+		ft_strncmp(str, ARG_ALLOW_COMMENT, sizeof(ARG_ALLOW_COMMENT)) == 0
+		|| ft_strncmp(
+			str,
+			ARG_ALLOW_COMMENT_LONG,
+			sizeof(ARG_ALLOW_COMMENT_LONG)
+		) == 0
+	);
+}

--- a/srcs/args/_arg_atoi.c
+++ b/srcs/args/_arg_atoi.c
@@ -34,7 +34,7 @@ int	_arg_atoi(
 	if (i == 0)
 		return (-1);
 	i = 0;
-	while (*str == '0')
+	while (*str != '\0')
 		i = (i * 10) + (*str++ - '0');
 	return (i);
 }

--- a/srcs/args/_arg_atoi.c
+++ b/srcs/args/_arg_atoi.c
@@ -1,0 +1,40 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   _arg_atoi.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 23:20:36 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/08 23:51:15 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <ft_is/ft_is.h>
+
+#include "_args.h"
+
+#define MAX_INT_LEN 6
+
+__attribute__((nonnull))
+int	_arg_atoi(
+	const char *str
+)
+{
+	int	i;
+
+	i = 0;
+	while (str[i] != '\0')
+	{
+		if (!ft_isdigit(str[i]))
+			return (-1);
+		if (MAX_INT_LEN < ++i)
+			return (-1);
+	}
+	if (i == 0)
+		return (-1);
+	i = 0;
+	while (*str == '0')
+		i = (i * 10) + (*str++ - '0');
+	return (i);
+}

--- a/srcs/args/_arg_height.c
+++ b/srcs/args/_arg_height.c
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   _arg_height.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 23:00:03 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/08 23:53:49 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <ft_string/ft_string.h>
+
+#include "_args.h"
+
+bool	_is_arg_height(
+	const char *str
+)
+{
+	return (
+		ft_strncmp(str, ARG_HEIGHT, sizeof(ARG_HEIGHT)) == 0
+		|| ft_strncmp(str, ARG_HEIGHT_LONG, sizeof(ARG_HEIGHT_LONG)) == 0
+	);
+}
+
+bool	_parse_arg_height(
+	t_app *args,
+	int *i,
+	int argc,
+	const char *argv[]
+)
+{
+	if (argc <= *i + 1)
+		return (errstr_retint("Too few arguments", NULL, false));
+	args->height = _arg_atoi(argv[*i + 1]);
+	*i += 1;
+	if (args->height < 0)
+		return (errstr_retint("Invalid argument (height)", argv[*i], false));
+	return (true);
+}

--- a/srcs/args/_arg_height.c
+++ b/srcs/args/_arg_height.c
@@ -12,6 +12,8 @@
 
 #include <ft_string/ft_string.h>
 
+#include <utils.h>
+
 #include "_args.h"
 
 bool	_is_arg_height(

--- a/srcs/args/_arg_width.c
+++ b/srcs/args/_arg_width.c
@@ -12,6 +12,8 @@
 
 #include <ft_string/ft_string.h>
 
+#include <utils.h>
+
 #include "_args.h"
 
 bool	_is_arg_width(

--- a/srcs/args/_arg_width.c
+++ b/srcs/args/_arg_width.c
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   _arg_width.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 23:00:03 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/08 23:53:09 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <ft_string/ft_string.h>
+
+#include "_args.h"
+
+bool	_is_arg_width(
+	const char *str
+)
+{
+	return (
+		ft_strncmp(str, ARG_WIDTH, sizeof(ARG_WIDTH)) == 0
+		|| ft_strncmp(str, ARG_WIDTH_LONG, sizeof(ARG_WIDTH_LONG)) == 0
+	);
+}
+
+bool	_parse_arg_width(
+	t_app *args,
+	int *i,
+	int argc,
+	const char *argv[]
+)
+{
+	if (argc <= *i + 1)
+		return (errstr_retint("Too few arguments", NULL, false));
+	args->width = _arg_atoi(argv[*i + 1]);
+	*i += 1;
+	if (args->width < 0)
+		return (errstr_retint("Invalid argument (width)", argv[*i], false));
+	return (true);
+}

--- a/srcs/args/_args.h
+++ b/srcs/args/_args.h
@@ -53,6 +53,12 @@ bool	_is_arg_width(
 		__attribute__((nonnull))
 		;
 
+bool	_is_arg_allow_comment(
+			const char *str
+			)
+		__attribute__((nonnull))
+		;
+
 bool	_parse_arg_width(
 			t_app *args,
 			int *i,

--- a/srcs/args/_args.h
+++ b/srcs/args/_args.h
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   _args.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 22:48:58 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/08 23:56:14 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef _ARGS_H
+# define _ARGS_H
+
+# include <rt_types.h>
+# include <stdbool.h>
+
+# define ARG_WIDTH "-w"
+# define ARG_WIDTH_LONG "--width"
+# define ARG_HEIGHT "-h"
+# define ARG_HEIGHT_LONG "--height"
+
+# define ARG_ALLOW_COMMENT "-c"
+# define ARG_ALLOW_COMMENT_LONG "--allow-comment"
+
+bool	_print_too_few_args(const char *msg);
+
+int		_arg_atoi(
+			const char *str
+			)
+		__attribute__((nonnull))
+		;
+
+bool	_is_arg_height(
+			const char *str
+			)
+		__attribute__((nonnull))
+		;
+
+bool	_parse_arg_height(
+			t_app *args,
+			int *i,
+			int argc,
+			const char *argv[]
+			)
+		__attribute__((nonnull))
+		;
+
+bool	_is_arg_width(
+			const char *str
+			)
+		__attribute__((nonnull))
+		;
+
+bool	_parse_arg_width(
+			t_app *args,
+			int *i,
+			int argc,
+			const char *argv[]
+			)
+		__attribute__((nonnull))
+		;
+
+#endif

--- a/srcs/args/parse_argv.c
+++ b/srcs/args/parse_argv.c
@@ -14,6 +14,8 @@
 #include <rt_types.h>
 #include <utils.h>
 
+#include "_args.h"
+
 #define DEFAULT_HEIGHT 480
 #define DEFAULT_WIDTH 640
 
@@ -45,7 +47,6 @@ bool	parse_argv(
 )
 {
 	int		i;
-	bool	result;
 
 	if (argc < 2)
 		return (errstr_retint("Too few arguments", NULL, false));

--- a/srcs/args/parse_argv.c
+++ b/srcs/args/parse_argv.c
@@ -1,0 +1,63 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_argv.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/08 22:42:36 by kfujita           #+#    #+#             */
+/*   Updated: 2023/12/09 00:02:44 by kfujita          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <args.h>
+#include <rt_types.h>
+#include <utils.h>
+
+#define DEFAULT_HEIGHT 480
+#define DEFAULT_WIDTH 640
+
+static bool	_parse_argv(
+	t_app *app,
+	int *i,
+	int argc,
+	const char *argv[]
+)
+{
+	if (_is_arg_width(argv[*i]))
+		return (_parse_arg_width(app, i, argc, argv));
+	else if (_is_arg_height(argv[*i]))
+		return (_parse_arg_height(app, i, argc, argv));
+	else if (_is_arg_allow_comment(argv[*i]))
+	{
+		app->allow_comment = true;
+		return (true);
+	}
+	else
+		app->file_name = argv[*i];
+	return (true);
+}
+
+bool	parse_argv(
+	int argc,
+	const char *argv[],
+	t_app *app
+)
+{
+	int		i;
+	bool	result;
+
+	if (argc < 2)
+		return (errstr_retint("Too few arguments", NULL, false));
+	i = 0;
+	while (++i < argc)
+	{
+		if (!_parse_argv(app, &i, argc, argv))
+			return (false);
+	}
+	if (app->height <= 0)
+		app->height = DEFAULT_HEIGHT;
+	if (app->width <= 0)
+		app->width = DEFAULT_WIDTH;
+	return (true);
+}

--- a/srcs/loader/_ignore_comment.c
+++ b/srcs/loader/_ignore_comment.c
@@ -14,8 +14,6 @@
 
 #include "_rt_loader.h"
 
-#if defined(DEBUG) || defined(ENABLE_PNG)
-
 __attribute__((nonnull))
 static bool	_is_comment(const char *line)
 {
@@ -37,13 +35,3 @@ void	_ignore_comment(char **arr)
 		arr[i++] = NULL;
 	}
 }
-
-#else
-
-void	_ignore_comment(char **arr)
-{
-	(void)arr;
-	return ;
-}
-
-#endif

--- a/srcs/loader/load_rt.c
+++ b/srcs/loader/load_rt.c
@@ -62,6 +62,7 @@ static t_lderr	_init_struct(
 __attribute__((nonnull))
 t_lderr	load_rt(
 	int fd,
+	bool allow_comment,
 	t_scene *dst
 )
 {
@@ -78,7 +79,7 @@ t_lderr	load_rt(
 		tmp = _remove_lf(get_next_line(&gnl));
 		if (tmp == NULL)
 			break ;
-		err = load_rt_line(tmp, dst);
+		err = load_rt_line(tmp, allow_comment, dst);
 		free(tmp);
 	}
 	if (errno != 0)

--- a/srcs/loader/loader.c
+++ b/srcs/loader/loader.c
@@ -101,7 +101,7 @@ t_lderr	load_rt_line(
 		return (perr_retint("ft_split", LOAD_ERR_PRINTED));
 	err = LOAD_ERR_SUCCESS;
 	if (allow_comment)
-	_ignore_comment(arr);
+		_ignore_comment(arr);
 	if (arr[0] != NULL)
 		err = _parse_input(arr, dst);
 	free2darr((void **)arr);

--- a/srcs/loader/loader.c
+++ b/srcs/loader/loader.c
@@ -87,6 +87,7 @@ static t_lderr	_parse_input(char *const arr[], t_scene *scene)
 __attribute__((nonnull))
 t_lderr	load_rt_line(
 	const char *line,
+	bool allow_comment,
 	t_scene *dst
 )
 {
@@ -99,6 +100,7 @@ t_lderr	load_rt_line(
 	if (arr == NULL)
 		return (perr_retint("ft_split", LOAD_ERR_PRINTED));
 	err = LOAD_ERR_SUCCESS;
+	if (allow_comment)
 	_ignore_comment(arr);
 	if (arr[0] != NULL)
 		err = _parse_input(arr, dst);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -108,6 +108,7 @@ int	main(
 
 	if (argc < 2)
 		return (errstr_retint("usage", "miniRT <RT file name>", EXIT_FAILURE));
+	app = (t_app){0};
 	if (!parse_argv(argc, argv, &app))
 		return (EXIT_FAILURE);
 	if (!canvas_init(&canvas, app.height, app.width))

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -26,6 +26,7 @@
 // - sprintf
 #include <stdio.h>
 
+#include <args.h>
 #include <canvas.h>
 #include <renderer.h>
 #include <rt_loader.h>
@@ -104,22 +105,24 @@ int	main(
 )
 {
 	t_cnvas	canvas;
-	t_scene	scene;
+	t_app	app;
 	bool	ret;
 
 	if (argc != 2)
 		return (errstr_retint("usage", "miniRT <RT file name>", EXIT_FAILURE));
-	if (!canvas_init(&canvas, CANVAS_HEIGHT, CANVAS_WIDTH))
+	if (!parse_argv(argc, argv, &app))
+		return (EXIT_FAILURE);
+	if (!canvas_init(&canvas, app.height, app.width))
 		return (perr_retint("canvas_init", 1));
-	if (!_load_rt_file(argv[1], &scene))
+	if (!_load_rt_file(app.file_name, &(app.scene)))
 	{
 		canvas_dispose(&canvas);
 		return (EXIT_FAILURE);
 	}
-	render(&canvas, &scene);
-	ret = _do_show(&canvas, &scene);
+	render(&canvas, &(app.scene));
+	ret = _do_show(&canvas, &(app.scene));
 	canvas_dispose(&canvas);
-	vect_dispose(&(scene.objs));
+	vect_dispose(&(app.scene.objs));
 	return (!ret);
 }
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -34,12 +34,10 @@
 #include <utils.h>
 #include <mymlx.h>
 
-#define CANVAS_HEIGHT 480
-#define CANVAS_WIDTH 640
-
 __attribute__((nonnull))
 static bool	_load_rt_file(
 	const char *fname,
+	bool allow_comment,
 	t_scene *dst
 )
 {
@@ -49,7 +47,7 @@ static bool	_load_rt_file(
 	fd = open(fname, O_RDONLY);
 	if (fd < 0)
 		return (perr_retint("open RT file", false));
-	err = load_rt(fd, dst);
+	err = load_rt(fd, allow_comment, dst);
 	if (err == LOAD_ERR_SUCCESS)
 		return (true);
 	vect_dispose(&(dst->objs));
@@ -114,7 +112,7 @@ int	main(
 		return (EXIT_FAILURE);
 	if (!canvas_init(&canvas, app.height, app.width))
 		return (perr_retint("canvas_init", 1));
-	if (!_load_rt_file(app.file_name, &(app.scene)))
+	if (!_load_rt_file(app.file_name, app.allow_comment, &(app.scene)))
 	{
 		canvas_dispose(&canvas);
 		return (EXIT_FAILURE);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -106,7 +106,7 @@ int	main(
 	t_app	app;
 	bool	ret;
 
-	if (argc != 2)
+	if (argc < 2)
 		return (errstr_retint("usage", "miniRT <RT file name>", EXIT_FAILURE));
 	if (!parse_argv(argc, argv, &app))
 		return (EXIT_FAILURE);

--- a/srcs/utils/error_retint.c
+++ b/srcs/utils/error_retint.c
@@ -27,6 +27,8 @@
 
 #include <utils.h>
 
+#define ERROR_STR "Error\n"
+
 int	perr_retint(
 	const char *str,
 	int ret
@@ -50,6 +52,7 @@ int	errstr_retint(
 	int ret
 )
 {
+	write(STDERR_FILENO, ERROR_STR, sizeof(ERROR_STR) - 1);
 	if (str != NULL)
 		ft_putstr_fd(str, STDERR_FILENO);
 	if (msg != NULL)


### PR DESCRIPTION
課題要件には無いけど、あった方が便利なので追加した。

- `[-w|--width] WIDTH_PX`: ウィンドウの幅 (0以上 999,999以下)
- `[-h|--height] HEIGHT_PX`: ウィンドウの高さ (0以上 999,999以下)
- `[-c|--allow-comment]`: コメントを許可するかどうか (引数に一つでも含めることで、コメントが許可される)

上記以外の引数はRTファイル名として解釈される。

なお、Widthが0のときは、デフォルト値 (640) が使用される。同じく高さ0の時は480が使用される。
また、同じオプションを複数記述した場合、最後に記述されたものが適用される。

引数に一つでもエラーがあった場合は、処理を続行できずエラー扱いとなる。
